### PR TITLE
05-layouts.md typo fix: treated to created

### DIFF
--- a/site/content/docs/05-layouts.md
+++ b/site/content/docs/05-layouts.md
@@ -2,7 +2,7 @@
 title: Layouts
 ---
 
-So far, we've treated pages as entirely standalone components — upon navigation, the existing component will be destroyed, and a new one will take its place.
+So far, we've created pages as entirely standalone components — upon navigation, the existing component will be destroyed, and a new one will take its place.
 
 But in many apps, there are elements that should be visible on *every* page, such as top-level navigation or a footer. Instead of repeating them in every page, we can use *layout* components.
 


### PR DESCRIPTION
The first sentence starts with: "So far, we've **treated** pages..."  It should read: "So far, we've **created** pages..."  I do not believe the current version makes grammatical sense.  I did not see any tests included for docs.  If I missed them I would be happy to write a test to help this pull request along.



### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ -] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ -] Run the tests tests with `npm test` or `yarn test`)
